### PR TITLE
feat: bootstrap liminal 2.0 mvp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/liminal?schema=public"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci || npm i
+      - run: npm run build --if-present
+      - run: npm run test --if-present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,6 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: '20' }
       - run: npm ci || npm i
+      - run: npx playwright install --with-deps
       - run: npm run build --if-present
       - run: npm run test --if-present

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Dependencies
+/node_modules
+
+# Next.js
+/.next/
+/out/
+
+# Production
+/build
+
+# Misc
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Prisma
+/prisma/*.db
+
+# Playwright
+/test-results/
+/playwright-report/
+BlobReport/
+
+# TypeScript
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# Liminal-2.0.-For-people
+# LIMINAL 2.0 — For People
+
+MVP: утренние 3 инсайта (микропривычка, рефрейм, мировой штрих) и вечерняя свёртка.  
+TTFI < 60s. Next.js 15, React 19, TS, Tailwind, Prisma (схема), Playwright.
+
+## Запуск
+```bash
+npm install
+npm run dev   # http://localhost:3000
+npm run test  # e2e
+```
+
+Страницы: /morning, /evening, /history.
+
+---
+
+## Коммиты (последовательно)
+
+chore(init): bootstrap Next 15 (TS, Tailwind, app router, src)
+feat(prisma): add schema (User, Entry, Insight, Rule) and .env.example
+feat(pages): add morning/evening/history pages (MVP, no DB)
+test(e2e): add Playwright config and morning TTFI test
+ci: add GitHub Actions minimal workflow
+docs: update README (run instructions)
+
+## Критерии успеха
+- `npm run dev` стартует без ошибок, страницы доступны.
+- Тест `tests/morning.spec.ts` проходит.
+- Build (`npm run build`) успешен.
+- CI зелёный на `main`.
+- В коде нет route-groups, `.git` на месте.
+
+---
+
+Если окружение у агента будет «ломаться из-за .git» — пересоздать сессию/воркспейс и повторить команды **только в корне репо**. Дальше допилим PWA, БД и auth — уже на Неделе 2.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,8 @@
+import next from "eslint-config-next";
+
+export default [
+  {
+    ignores: ["**/node_modules/**", "**/.next/**", "**/out/**"]
+  },
+  ...next
+];

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "liminal-2-0-for-people",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
+  },
+  "dependencies": {
+    "next": "15.0.3",
+    "react": "rc",
+    "react-dom": "rc"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.45.3",
+    "@prisma/client": "5.19.1",
+    "@types/node": "20.14.10",
+    "@types/react": "19.0.1",
+    "@types/react-dom": "19.0.1",
+    "autoprefixer": "10.4.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "15.0.3",
+    "postcss": "8.4.38",
+    "prisma": "5.19.1",
+    "tailwindcss": "3.4.13",
+    "typescript": "5.6.2"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  reporter: 'list',
+  use: { baseURL: 'http://localhost:3000', trace: 'on-first-retry' },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: { command: 'npm run dev', url: 'http://localhost:3000', reuseExistingServer: true }
+});

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,39 @@
+generator client { provider = "prisma-client-js" }
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  createdAt DateTime @default(now())
+  entries   Entry[]
+  insights  Insight[]
+}
+
+model Entry {
+  id        String   @id @default(cuid())
+  userId    String
+  kind      String   // "morning" | "evening" | "note"
+  content   Json
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
+}
+
+model Insight {
+  id        String   @id @default(cuid())
+  userId    String
+  date      DateTime @default(now())
+  body      Json     // {microHabit, reframing, worldTrend}
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
+}
+
+model Rule {
+  id      String @id @default(cuid())
+  tag     String
+  pattern String
+  payload Json
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:

--- a/src/app/evening/page.tsx
+++ b/src/app/evening/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+
+export default function Evening() {
+  const [done, setDone] = useState("");
+  const [grat, setGrat] = useState("");
+  const [ok, setOk] = useState(false);
+
+  const save = () => {
+    console.log({ done, grat, at: new Date().toISOString() });
+    setOk(true);
+    setTimeout(() => setOk(false), 1600);
+  };
+
+  return (
+    <main className="min-h-dvh bg-gradient-to-br from-purple-900 to-pink-900 p-8">
+      <div className="max-w-3xl mx-auto grid gap-6">
+        <h2 className="text-3xl font-bold text-white">Вечерняя свёртка</h2>
+        <label className="grid gap-2">
+          <span className="text-purple-200">Что получилось / что заметил?</span>
+          <textarea
+            rows={5}
+            className="p-4 rounded bg-white/10 text-white border border-white/20"
+            value={done}
+            onChange={(e) => setDone(e.target.value)}
+            placeholder="Опиши своими словами..."
+          />
+        </label>
+        <label className="grid gap-2">
+          <span className="text-purple-200">Чему рад / за что благодарен?</span>
+          <textarea
+            rows={5}
+            className="p-4 rounded bg-white/10 text-white border border-white/20"
+            value={grat}
+            onChange={(e) => setGrat(e.target.value)}
+            placeholder="Даже маленькие вещи имеют значение..."
+          />
+        </label>
+        <button
+          disabled={!done || !grat}
+          onClick={save}
+          className="px-6 py-3 rounded bg-purple-600 text-white disabled:opacity-50"
+        >
+          {ok ? "✓ Сохранено" : "Сохранить день"}
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,11 @@
+export default function History() {
+  return (
+    <main className="min-h-dvh bg-gradient-to-br from-slate-900 to-slate-800 p-8 grid place-items-center">
+      <div className="max-w-3xl text-center space-y-4">
+        <h2 className="text-3xl font-bold text-white">История</h2>
+        <p className="text-slate-300 text-lg">Здесь появится лента утренних инсайтов и вечерних ответов.</p>
+        <p className="text-slate-500 text-sm">(реализация с БД — на Неделе 2)</p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "LIMINAL 2.0 — For People",
+  description: "Daily cycle: morning insights & evening reflection",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ru">
+      <body className="min-h-dvh antialiased">{children}</body>
+    </html>
+  );
+}

--- a/src/app/morning/page.tsx
+++ b/src/app/morning/page.tsx
@@ -1,0 +1,49 @@
+type Insight = { microHabit: string; reframing: string; worldTrend: string };
+
+const INSIGHTS: Insight[] = [
+  {
+    microHabit: "Стакан воды и 3 глубоких вдоха",
+    reframing: "Выбери один главный шаг вместо десяти мелких",
+    worldTrend: "AI-ассистенты становятся персональными коучами",
+  },
+  {
+    microHabit: "2 минуты растяжки после подъёма",
+    reframing: "Ошибки — это данные, а не приговор",
+    worldTrend: "Микрообучение вытесняет длинные курсы",
+  },
+  {
+    microHabit: "3 благодарности в заметках",
+    reframing: "Прогресс — это движение, не идеал",
+    worldTrend: "Удалёнка меняет географию талантов",
+  },
+];
+
+const pick = <T,>(a: T[]) => a[Math.floor(Math.random() * a.length)];
+
+export default function Morning() {
+  const i = pick(INSIGHTS);
+  return (
+    <main className="min-h-dvh bg-gradient-to-br from-blue-900 to-indigo-900 p-8">
+      <div className="max-w-3xl mx-auto grid gap-6">
+        <h2 className="text-3xl font-bold text-white">Твои 3 пункта на утро</h2>
+        <section className="bg-white/10 p-6 rounded-xl border border-white/20">
+          <h3 className="text-blue-200 text-sm uppercase mb-2">Микропривычка</h3>
+          <p className="text-white text-lg">{i.microHabit}</p>
+        </section>
+        <section className="bg-white/10 p-6 rounded-xl border border-white/20">
+          <h3 className="text-blue-200 text-sm uppercase mb-2">Рефрейм</h3>
+          <p className="text-white text-lg">{i.reframing}</p>
+        </section>
+        <section className="bg-white/10 p-6 rounded-xl border border-white/20">
+          <h3 className="text-blue-200 text-sm uppercase mb-2">Мировой штрих</h3>
+          <p className="text-white text-lg">{i.worldTrend}</p>
+        </section>
+        <div className="flex gap-3">
+          <button className="px-4 py-2 rounded bg-blue-600 text-white">Применить</button>
+          <button className="px-4 py-2 rounded border border-white/30 text-white">Сохранить</button>
+          <button className="px-4 py-2 rounded border border-white/30 text-white">Пропустить</button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <main className="min-h-dvh grid place-items-center bg-gradient-to-br from-slate-900 to-slate-800 p-8">
+      <div className="text-center space-y-6 max-w-2xl">
+        <h1 className="text-5xl font-bold text-white">LIMINAL 2.0</h1>
+        <p className="text-slate-300 text-lg">Утро → 3 инсайта. Вечер → свёртка. История → твой путь.</p>
+        <nav className="flex gap-4 justify-center flex-wrap">
+          <Link className="px-6 py-3 rounded-lg bg-blue-600 text-white" href="/morning">Утреннее</Link>
+          <Link className="px-6 py-3 rounded-lg bg-purple-600 text-white" href="/evening">Вечернее</Link>
+          <Link className="px-6 py-3 rounded-lg bg-slate-600 text-white" href="/history">История</Link>
+        </nav>
+      </div>
+    </main>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tests/morning.spec.ts
+++ b/tests/morning.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test('morning shows 3 insights within 60s (TTFI)', async ({ page }) => {
+  const start = Date.now();
+  await page.goto('/morning');
+  await expect(page.getByText('Твои 3 пункта на утро')).toBeVisible();
+  await expect(page.getByText('Микропривычка')).toBeVisible();
+  await expect(page.getByText('Рефрейм')).toBeVisible();
+  await expect(page.getByText('Мировой штрих')).toBeVisible();
+  expect(Date.now() - start).toBeLessThan(60000);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cts", "**/*.mts", "**/*.d.ts", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 15 project with Tailwind, TypeScript, linting, and project tooling
- add MVP morning, evening, and history pages alongside Prisma schema and env template
- configure Playwright test suite, CI workflow, and updated README for local usage

## Testing
- npm install *(fails: 403 Forbidden - registry access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e190cac098832da38e772b2a916b46